### PR TITLE
Merge Main Addon Release 1

### DIFF
--- a/lua/autorun/ba2_shared.lua
+++ b/lua/autorun/ba2_shared.lua
@@ -112,7 +112,7 @@ BA2_ZombieTypes = {
 
 DMG_BIOVIRUS = 83598
 
-BA2_MODVERSION = "Release Hotfix 0A"
+BA2_MODVERSION = "Release 1"
 
 -- Sounds
 sound.Add({
@@ -365,7 +365,7 @@ sound.Add({
 
 -- Other
 game.AddDecal("BA2_VirusBloodStain","decals/bloodstain_002")
-team.SetUp(83598,"NPCs",Color(250,46,46),false)
+team.SetUp(83598,"BA2_NPCs",Color(250,46,46),false)
 
 -- if ArcMedShots then
 --     ArcMedShots["ba2"] = {

--- a/lua/autorun/client/ba2_client_init.lua
+++ b/lua/autorun/client/ba2_client_init.lua
@@ -65,6 +65,9 @@ function BA2_NoNavmeshWarn()
         btn:SetPos(25,85)
         btn:SetText("Yes")
         btn.DoClick = function()
+            LocalPlayer():ChatPrint("A navmesh is now being generated. What happens next will vary depending on the map.")
+            LocalPlayer():ChatPrint("If you observe major lag, stand by until the map restarts. You can monitor the algorithm's progress in the console.")
+            LocalPlayer():ChatPrint("If not, automatic generation has failed and is incompatible with this map.")
             RunConsoleCommand("nav_generate")
             DFrame:Remove()
             ConfFrame:Remove()
@@ -113,7 +116,13 @@ net.Receive("BA2ZomDeathNotice",function()
         name = attacker:GetName()
         team = attacker:Team()
     else
-        name = "#"..attacker:GetClass()
+        if IsValid(attacker) then
+            name = "#"..attacker:GetClass()
+        elseif attacker:IsWorld() then
+            name = "#worldspawn"
+        else
+            name = " "
+        end
         team = 83598
     end
     if attacker == inflictor and (attacker:IsPlayer() or attacker:IsNPC()) then
@@ -217,7 +226,7 @@ hook.Add("HUDPaint","BA2_GasmaskHUD",function()
         end
 
         draw.DrawText("FILTER: "..filterPct.."%","DermaLarge",ScrW() * .01,ScrH() * .01,textColor)
-        draw.DrawText("RESERVE: "..LocalPlayer():GetNWInt("BA2_GasmaskFilters",0),"Trebuchet24",ScrW() * .01,ScrH() * .035,textColor)
+        draw.DrawText("RESERVE: "..LocalPlayer():GetNWInt("BA2_GasmaskFilters",0),"Trebuchet24",ScrW() * .01,ScrH() * .04,textColor)
     end
 end)
 hook.Add("DrawOverlay","BA2_CameraSmog",function()
@@ -232,6 +241,15 @@ end)
 
 -- Q-menu options
 local adminString = "You must be a server admin to modify these settings. You're still allowed to look, though.\n"
+
+function CreatePresets(vars)
+    local presets = vgui.Create("ControlPresets")
+    for i,v in pairs(vars) do
+        presets:AddConVar(v)
+    end
+
+    return presets
+end
 
 hook.Add("PopulateToolMenu","ba2_options",function(panel)
     -- ABOUT
@@ -249,9 +267,17 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
         else
             panel:Help(BA2_MODVERSION.." (Workshop Edition)")
         end
-
+        
         local url = vgui.Create("DLabelURL")
-        url:SetText("GitHub Repository")
+        url:SetText("Workshop")
+        url:SetURL("https://steamcommunity.com/workshop/filedetails/?id=2416750969")
+        panel:AddItem(url)
+        local url = vgui.Create("DLabelURL")
+        url:SetText("Wiki")
+        url:SetURL("https://github.com/Sninctbur/BA2/wiki")
+        panel:AddItem(url)
+        local url = vgui.Create("DLabelURL")
+        url:SetText("Source Code")
         url:SetURL("https://github.com/Sninctbur/BA2")
         panel:AddItem(url)
         local url = vgui.Create("DLabelURL")
@@ -276,9 +302,9 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
     end)
 
     -- COSMETIC
-    spawnmenu.AddToolMenuOption("Options","Bio-Annihilation II","ba2_config_cos","Cosmetic","","",function(panel)
+    spawnmenu.AddToolMenuOption("Options","Bio-Annihilation II","ba2_config_cos","Customs","","",function(panel)
         panel:Help("You can type \"find ba2_cos\" in the developer console for more information about these settings.")
-        panel:Help("These settings change the appearance of zombies. You can set Custom Infected models here.")
+        panel:Help("These settings change the appearance of Custom Infected.")
 
         -- panel:Help("Default Infected Color:")
         -- local mixer = vgui.Create("DColorMixer",panel)
@@ -326,7 +352,7 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
     end)
 
     -- HORDE SPAWNER
-    spawnmenu.AddToolMenuOption("Options","Bio-Annihilation II","ba2_config_hs","Horde Spawner","","",function(panel)
+    spawnmenu.AddToolMenuOption("Options","Bio-Annihilation II","ba2_config_hs","Spawners","","",function(panel)
         if(LocalPlayer():IsAdmin() == false) then
             panel:ControlHelp(adminString)
         end
@@ -339,13 +365,19 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
         panel:NumSlider("Spawn Interval","ba2_hs_interval",0.1,30,1)
         panel:NumSlider("Safe Radius","ba2_hs_saferadius",0,10000,0)
 
-        local comboBox = panel:ComboBox("Zombie Appearance","ba2_hs_appearance")
-        comboBox:AddChoice("0. Citizens",0)
-        comboBox:AddChoice("1. Rebels",1)
-        comboBox:AddChoice("2. Combine",2)
-        comboBox:AddChoice("3. Custom",3)
-        comboBox:AddChoice("4. Any of the above",4)
-        comboBox:AddChoice("5. Any except Custom Infected",5)
+        -- local comboBox = panel:ComboBox("Zombie Appearance","ba2_hs_appearance")
+        -- comboBox:AddChoice("0. Citizens",0)
+        -- comboBox:AddChoice("1. Rebels",1)
+        -- comboBox:AddChoice("2. Combine",2)
+        -- comboBox:AddChoice("3. Custom",3)
+        -- comboBox:AddChoice("4. Any of the above",4)
+        -- comboBox:AddChoice("5. Any except Custom Infected",5)
+
+        panel:Help("Appearance:")
+        panel:CheckBox("Citizen","ba2_hs_appearance_0")
+        panel:CheckBox("Rebel","ba2_hs_appearance_1")
+        panel:CheckBox("Combine","ba2_hs_appearance_2")
+        panel:CheckBox("Custom","ba2_hs_appearance_3")
 
         panel:Button("Delete Active Horde Spawner","ba2_hs_delete")
     end)
@@ -391,6 +423,7 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
         panel:NumSlider("Infection Multiplier","ba2_zom_infectionmult",0,10,2)
         panel:NumSlider("Detection Range","ba2_zom_range",0,50000,0)
         panel:NumSlider("Non-Headshot Damage Multiplier","ba2_zom_nonheadshotmult",0,1,2)
+        panel:NumSlider("Limb Damage Multiplier","ba2_zom_limbdamagemult",0,1,2)
         panel:NumSlider("Infected Raise Time","ba2_zom_emergetime",0,300,0)
         panel:NumSlider("Medic Vial Drop Chance","ba2_zom_medicdropchance",0,100,0)
 
@@ -403,8 +436,9 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
 
         panel:CheckBox("Attack Props","ba2_zom_breakobjects")
         panel:ControlHelp("The next options require Attack Props")
-        panel:CheckBox("Unfreeze/Unconstrain","ba2_zom_breakphys")
+        panel:CheckBox("Unfreeze/Unconstrain Props","ba2_zom_breakphys")
         panel:CheckBox("Break Down Doors","ba2_zom_breakdoors")
+        panel:NumSlider("Prop Damage Multiplier","ba2_zom_propdmgmult",0,10,2)
 
         panel:NumSlider("Door Respawn Time","ba2_zom_doorrespawn",0,300,0)
         panel:ControlHelp("Set to 0 to not respawn doors until map cleanup")
@@ -434,6 +468,11 @@ hook.Add("PopulateToolMenu","ba2_options",function(panel)
         panel:CheckBox("Air Waste View Shake","ba2_misc_airwasteshake")
         panel:CheckBox("No Navmesh Warning","ba2_misc_navmeshwarn")
         panel:CheckBox("Zombie Kill Credit","ba2_misc_addscore")
+
+        panel:Help("")
+
+        -- panel:CheckBox("Count Zombies as NPCs","ba2_misc_isnpc")
+        -- panel:ControlHelp("May cause Lua errors in other addons - enable at your own risk")
     end)
 end)
 

--- a/lua/autorun/server/ba2_master_init.lua
+++ b/lua/autorun/server/ba2_master_init.lua
@@ -16,17 +16,21 @@ CreateConVar("ba2_hs_interval",1,FCVAR_ARCHIVE,[[The Horde Spawner will wait thi
     The lower this is, the faster zombies will spawn.]],0.1)
 CreateConVar("ba2_hs_saferadius",500,FCVAR_ARCHIVE,[[The Horde Spawner cannot spawn zombies closer to potential targets than this distance.
     You may need to turn this value down on very small maps.]],0)
-CreateConVar("ba2_hs_appearance",5,FCVAR_ARCHIVE,[[Configures the type of zombie the Horde Spawner creates.
-    0: Citizens
-    1: Rebels
-    2: Cobmine
-    3: Custom
-    4: Any of the above
-    5: Any except Custom Infected]],0,5
-)
-CreateConVar("ba2_hs_cleanup",1,FCVAR_ARCHIVE,[[If enabled, the Horde Spawner will also remove all of the zombies it created when it gets deleted.]])
+-- CreateConVar("ba2_hs_appearance",5,FCVAR_ARCHIVE,[[Configures the type of zombie the Horde Spawner creates.
+--     0: Citizens
+--     1: Rebels
+--     2: Cobmine
+--     3: Custom
+--     4: Any of the above
+--     5: Any except Custom Infected]],0,5
+-- )
+CreateConVar("ba2_hs_appearance_0",1,FCVAR_ARCHIVE,[[If enabled, Spawners  will create Infected Citizens.]])
+CreateConVar("ba2_hs_appearance_1",1,FCVAR_ARCHIVE,[[If enabled, Spawners  will create Infected Rebels.]])
+CreateConVar("ba2_hs_appearance_2",1,FCVAR_ARCHIVE,[[If enabled, Spawners  will create Infected Combine.]])
+CreateConVar("ba2_hs_appearance_3",1,FCVAR_ARCHIVE,[[If enabled, Spawners  will create Custom Infected.]])
+CreateConVar("ba2_hs_cleanup",1,FCVAR_ARCHIVE,[[If enabled, Spawners will also remove all of the zombies it created when it gets deleted.]])
 concommand.Add("ba2_hs_delete",BA2_DestroyHS,nil,"Destroys the active Horde Spawner, if it exists.")
-CreateConVar("ba2_hs_notargetclean",1,FCVAR_ARCHIVE,[[If enabled, the Horde Spawner will delete and eventually respawn zombies who do not find a target within 6 sceonds of spawning.]])
+CreateConVar("ba2_hs_notargetclean",1,FCVAR_ARCHIVE,[[If enabled, the Horde Spawner will delete and eventually replace zombies who do not find a target within 6 sceonds of spawning.]])
 
 CreateConVar("ba2_inf_contagionmult",1,FCVAR_ARCHIVE,[[Mutliply the distance the Bio-Virus can spread to others by this amount.
     Set to 0 to disable contagion.]],0)
@@ -51,11 +55,14 @@ CreateConVar("ba2_zom_pursuitspeed",1,FCVAR_ARCHIVE,[[Configures the speed zombi
 )
 CreateConVar("ba2_zom_health",100,FCVAR_ARCHIVE,[[Zombies have this much health. Minimum 1. Only affects new zombies.]],1)
 CreateConVar("ba2_zom_dmgmult",1,FCVAR_ARCHIVE,[[Multiply zombie damage per attack by this amount.]],0)
+CreateConVar("ba2_zom_propdmgmult",1,FCVAR_ARCHIVE,[[Multiply zombie damage per attack to props and doors by this amount.
+Does not stack with ba2_zom_dmgmult.]],0)
 CreateConVar("ba2_zom_infectionmult",1,FCVAR_ARCHIVE,[[Multiply zombie infection per attack by this amount.]],0)
 CreateConVar("ba2_zom_range",10000,FCVAR_ARCHIVE,[[Multiply zombie targeting range by this amount.
     High values may result in more lag when there are no valid targets.
     Set to 0 to turn them into the most miserable beings in existence.]],0)
 CreateConVar("ba2_zom_nonheadshotmult",1,FCVAR_ARCHIVE,[[Multiply zombie damage received on non-headshots by this amount.]],0,1)
+CreateConVar("ba2_zom_limbdamagemult",.5,FCVAR_ARCHIVE,[[Multiply zombie damage received on limb shots by this amount.]],0,1)
 CreateConVar("ba2_zom_damagestun",1,FCVAR_ARCHIVE,[[If enabled, zombies will stagger if they take more than half their current health in damage.]])
 CreateConVar("ba2_zom_emergetime",8,FCVAR_ARCHIVE,[[After getting killed by an infectious source, entities will take this long to rise into a zombie.]])
 CreateConVar("ba2_zom_armdamage",1,FCVAR_ARCHIVE,[[If enabled, zombies can have their arms broken.
@@ -82,8 +89,16 @@ CreateConVar("ba2_misc_deathdropmask",1,FCVAR_ARCHIVE,[[If enabled, players will
 CreateConVar("ba2_misc_deathdropfilter",1,FCVAR_ARCHIVE,[[If enabled, players will drop all of their gas mask filters on death.]])
 CreateConVar("ba2_misc_headshoteff",1,FCVAR_ARCHIVE,[[If enabled, zombies' heads have a chance to comically explode when they are killed by a headshot.]])
 CreateConVar("ba2_misc_addscore",1,FCVAR_ARCHIVE,[[If enabled, killing a zombie will award a frag to the player who killed them.]])
+-- CreateConVar("ba2_misc_isnpc",0,FCVAR_ARCHIVE,[[If enabled, other addons will consider zombies an NPC for the purpose of IsNPC() checks.
+--     Enabling this may correct interactions with some addons (for example, JMod), but can cause Lua errors in others. Enable at your own risk.]])
 
 concommand.Add("ba2_misc_maggots",BA2_ToggleMaggotMode,nil,"If God had wanted you to live, he would not have created ME!")
+
+concommand.Add("ba2_gasmask",BA2_ToggleGasmask,nil)
+concommand.Add("ba2_dgasmask",BA2_DropGasmask,nil)
+concommand.Add("ba2_dfilter",BA2_DropFilter,nil)
+concommand.Add("ba2_ufilter",BA2_UFilter,nil)
+concommand.Add("ba2_cfilter",BA2_CheckFilter,nil)
 
 
 -- Net messages
@@ -108,7 +123,7 @@ function BA2_InfectionTick(ent)
     dmg:SetDamageCustom(DMG_BIOVIRUS)
     dmg:SetAttacker(BA2_InfectionManager())
     dmg:SetInflictor(BA2_InfectionManager())
-
+    
     local lastArmor = nil
     if ent:IsPlayer() and ent:Armor() > 0 then
         lastArmor = ent:Armor()
@@ -282,28 +297,98 @@ function BA2_DestroyHS()
     end
 end
 
-function BA2_DropGasmask(p)
-    local mask = ents.Create("ba2_gasmask")
-    mask:SetPos(p:EyePos())
-    mask:SetAngles(p:EyeAngles())
-    mask.BA2_FilterPct = p:GetNWInt("BA2_GasmaskFilterPct",100)
-    mask:Spawn()
-    mask:Activate()
-    mask:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 90)
 
-    BA2_GasmaskSound(p)
-    p:SetNWBool("BA2_GasmaskOn",false)
-    p:SetNWBool("BA2_GasmaskOwned",false)
+function BA2_ToggleGasmask(p)
+    if p:GetNWBool("BA2_GasmaskOwned",false) then
+        local bool = p:GetNWBool("BA2_GasmaskOn",false)
+
+        if bool then
+            p:EmitSound("npc/combine_soldier/zipline_hitground2.wav")
+            BA2_GasmaskSound(p)
+            
+        else
+            p:EmitSound("npc/combine_soldier/zipline_hitground1.wav")
+            BA2_GasmaskSound(p,p.BA2_MaskSoundName or "ba2/gasmask/mask_breathe_light.wav")
+        end
+
+        p:SetNWBool("BA2_GasmaskOn",not bool)
+        p:ViewPunch(Angle(10,0,0))
+    else
+        p:ChatPrint("You don't have a gas mask.")
+    end
+end
+
+function BA2_DropGasmask(p)
+    if !p:GetNWBool("BA2_GasmaskOwned",false) then
+        p:ChatPrint("You don't have a gas mask.")
+    else
+        p:EmitSound("npc/combine_soldier/zipline_hitground2.wav")
+        
+        local mask = ents.Create("ba2_gasmask")
+        mask:SetPos(p:EyePos())
+        mask:SetAngles(p:EyeAngles())
+        mask.BA2_FilterPct = p:GetNWInt("BA2_GasmaskFilterPct",100)
+        mask:Spawn()
+        mask:Activate()
+        mask:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 90)
+
+        BA2_GasmaskSound(p)
+        p:SetNWBool("BA2_GasmaskOn",false)
+        p:SetNWBool("BA2_GasmaskOwned",false)
+    end
 end
 function BA2_DropFilter(p)
-    local filter = ents.Create("ba2_gasmask_filter")
-    filter:SetPos(p:EyePos() + p:GetForward() * 9)
-    filter:SetAngles(p:EyeAngles())
-    filter:Spawn()
-    filter:Activate()
-    filter:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 900)
+    if p:GetNWInt("BA2_GasmaskFilters",0) == 0 then
+        p:ChatPrint("You don't have any reserve filters.")
+    else
+        local filter = ents.Create("ba2_gasmask_filter")
+        filter:SetPos(p:EyePos() + p:GetForward() * 9)
+        filter:SetAngles(p:EyeAngles())
+        filter:Spawn()
+        filter:Activate()
+        filter:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 900)
 
-    p:SetNWInt("BA2_GasmaskFilters",p:GetNWInt("BA2_GasmaskFilters",1) - 1)
+        p:SetNWInt("BA2_GasmaskFilters",p:GetNWInt("BA2_GasmaskFilters",1) - 1)
+        p:EmitSound("physics/metal/weapon_footstep2.wav")
+    end
+end
+function BA2_CheckFilter(p)
+    if p:GetNWBool("BA2_GasmaskOwned",false) then
+        p:ChatPrint("Gas Mask: "..math.ceil(p:GetNWInt("BA2_GasmaskFilterPct",0)).."%")
+    else
+        p:ChatPrint("Gas Mask: N/A")
+    end
+
+    p:ChatPrint("Reserve Filters: "..p:GetNWInt("BA2_GasmaskFilters",0))
+end
+function BA2_UFilter(p)
+    if !p:GetNWBool("BA2_GasmaskOwned",false) then
+        p:ChatPrint("You don't have a gas mask.")
+    elseif !GetConVar("ba2_misc_maskfilters"):GetBool() then
+        p:ChatPrint("These filters are perpetual. Swapping them out won't be necessary.")
+    elseif p:GetNWBool("BA2_GasmaskOn",false) then
+        p:ChatPrint("You will need to take off your gas mask first. (!gasmask)")
+    elseif p:GetNWInt("BA2_GasmaskFilters",0) == 0 then
+        p:ChatPrint("You don't have any reserve filters.")
+    elseif p:GetNWInt("BA2_GasmaskFilterPct",0) == 100 then
+        p:ChatPrint("Your gas mask already has a fresh filter.")
+    else
+        p:SetNWInt("BA2_GasmaskFilterPct",100)
+        p:SetNWInt("BA2_GasmaskFilters",p:GetNWInt("BA2_GasmaskFilters",1) - 1)
+
+        local prop = ents.Create("ba2_gasmask_filter")
+        prop.BA2_Scenic = true
+
+        prop:SetPos(p:EyePos() + p:GetForward() * 18)
+        prop:Spawn()
+        prop:Activate()
+        prop:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 900)
+
+        SafeRemoveEntityDelayed(prop,6)
+
+        p:EmitSound("physics/metal/weapon_footstep1.wav")
+        p:ViewPunch(Angle(10,0,0))
+    end
 end
 function BA2_GetActiveMask(p)
     if p:IsPlayer() then
@@ -346,14 +431,21 @@ hook.Add("OnEntityCreated","ba2_npcZomRelation",function(npc)
         for i,z in pairs(ents.FindByClass("nb_ba2_infected*")) do
             if npc.IsVJBaseSNPC then
                 timer.Simple(0,function()
-                    if IsValid(npc) then
+                    if IsValid(npc) and IsValid(z) and npc.VJ_AddCertainEntityAsEnemy ~= nil then
                         table.insert(npc.VJ_AddCertainEntityAsEnemy,z)
                         table.insert(npc.CurrentPossibleEnemies,z)
                     end
                 end)
             end
-
             npc:AddEntityRelationship(z,D_HT,1)
+        end
+    elseif string.StartWith(npc:GetClass(),"nb_ba2_infected") then -- Vrej, why must I hardcode this ;-;
+        for i,n in pairs(ents.FindByClass("npc_*")) do
+            if n.IsVJBaseSNPC then
+                table.insert(n.VJ_AddCertainEntityAsEnemy,npc)
+                table.insert(n.CurrentPossibleEnemies,npc)
+                n:AddEntityRelationship(npc,D_HT,1)
+            end
         end
     end
 end)
@@ -422,7 +514,7 @@ end)
 
 
 hook.Add("PlayerDeath","BA2_PlayerDeath",function(p,inf,ent,dmg)
-    if GetConVar("ba2_inf_plyraise"):GetBool() and (GetConVar("ba2_inf_romeromode"):GetBool() 
+    if inf ~= nil and GetConVar("ba2_inf_plyraise"):GetBool() and (GetConVar("ba2_inf_romeromode"):GetBool() 
         or (IsValid(p) and p.BA2Infection > 0) 
         or inf:GetClass() == BA2_InfectionManager()) then
         BA2_InfectionDeath(p,inf,ent,dmg)
@@ -453,16 +545,18 @@ hook.Add("EntityTakeDamage","BA2_OnDamage",function(e,dmg)
     end
 
     if e:Health() <= 0 then return end
-    if (GetConVar("ba2_inf_romeromode"):GetBool() or dmg:GetInflictor() == BA2_InfectionManager() or dmg:GetDamageCustom() == DMG_BIOVIRUS) 
+    if (GetConVar("ba2_inf_romeromode"):GetBool() or dmg:GetInflictor() == BA2_InfectionManager() or dmg:GetDamageCustom() == DMG_BIOVIRUS
+        or (e.BA2Infection and e.BA2Infection > 0 and !GetConVar("ba2_inf_killtoraise"):GetBool())) 
         and (e:IsNPC() or e:IsPlayer()) and e:Health() <= dmg:GetDamage() then
         if e:IsPlayer() and GetConVar("ba2_inf_plyraise"):GetBool() then
             gamemode.Call("PlayerDeath",e,dmg:GetInflictor(),dmg:GetAttacker(),dmg)
             e:KillSilent()
             SafeRemoveEntity(e:GetRagdollEntity())
             return true
-        elseif e:IsNPC() and BA2_ConvertibleNpcs[e:GetClass()] and GetConVar("ba2_inf_npcraise"):GetBool() then
+        elseif e:IsNPC() and (e.IsVJBaseSNPC_Human or BA2_ConvertibleNpcs[e:GetClass()]) and GetConVar("ba2_inf_npcraise"):GetBool() then
             BA2_InfectionDeath(e,dmg:GetInflictor(),dmg:GetAttacker(),dmg)
             gamemode.Call("OnNPCKilled",e,dmg:GetAttacker(),dmg:GetInflictor(),dmg)
+            e:DropWeapon()
             e:Remove()
             return true
         end
@@ -474,83 +568,20 @@ hook.Add("PlayerSay","BA2_Chat",function(p,msg)
     if !p:Alive() then return end
 
     if msg == "!dgasmask" then
-        if !p:GetNWBool("BA2_GasmaskOwned",false) then
-            p:ChatPrint("You don't have a gas mask.")
-        else
-            p:EmitSound("npc/combine_soldier/zipline_hitground2.wav")
-            BA2_DropGasmask(p)
-        end
-
+        BA2_DropGasmask(p)
         return ""
     end
     if msg == "!gasmask" then
-        if p:GetNWBool("BA2_GasmaskOwned",false) then
-            local bool = p:GetNWBool("BA2_GasmaskOn",false)
-
-            if bool then
-                p:EmitSound("npc/combine_soldier/zipline_hitground2.wav")
-                BA2_GasmaskSound(p)
-                
-            else
-                p:EmitSound("npc/combine_soldier/zipline_hitground1.wav")
-                BA2_GasmaskSound(p,p.BA2_MaskSoundName or "ba2/gasmask/mask_breathe_light.wav")
-            end
-
-            p:SetNWBool("BA2_GasmaskOn",not bool)
-            p:ViewPunch(Angle(10,0,0))
-        else
-            p:ChatPrint("You don't have a gas mask.")
-        end
-
+        BA2_ToggleGasmask(p)
         return ""
     elseif msg == "!cfilter" then
-        if p:GetNWBool("BA2_GasmaskOwned",false) then
-            p:ChatPrint("Gas Mask: "..math.ceil(p:GetNWInt("BA2_GasmaskFilterPct",0)).."%")
-        else
-            p:ChatPrint("Gas Mask: N/A")
-        end
-
-        p:ChatPrint("Reserve Filters: "..p:GetNWInt("BA2_GasmaskFilters",0))
-
+        BA2_CheckFilter(p)
         return ""
     elseif msg == "!ufilter" then
-        if !p:GetNWBool("BA2_GasmaskOwned",false) then
-            p:ChatPrint("You don't have a gas mask.")
-        elseif !GetConVar("ba2_misc_maskfilters"):GetBool() then
-            p:ChatPrint("These filters are perpetual. Swapping them out won't be necessary.")
-        elseif p:GetNWBool("BA2_GasmaskOn",false) then
-            p:ChatPrint("You will need to take off your gas mask first. (!gasmask)")
-        elseif p:GetNWInt("BA2_GasmaskFilters",0) == 0 then
-            p:ChatPrint("You don't have any reserve filters.")
-        elseif p:GetNWInt("BA2_GasmaskFilterPct",0) == 100 then
-            p:ChatPrint("Your gas mask already has a fresh filter.")
-        else
-            p:SetNWInt("BA2_GasmaskFilterPct",100)
-            p:SetNWInt("BA2_GasmaskFilters",p:GetNWInt("BA2_GasmaskFilters",1) - 1)
-
-            local prop = ents.Create("ba2_gasmask_filter")
-            prop.BA2_Scenic = true
-
-            prop:SetPos(p:EyePos() + p:GetForward() * 18)
-            prop:Spawn()
-            prop:Activate()
-            prop:GetPhysicsObject():ApplyForceCenter(p:GetForward() * 900)
-
-            SafeRemoveEntityDelayed(prop,6)
-
-            p:EmitSound("physics/metal/weapon_footstep1.wav")
-            p:ViewPunch(Angle(10,0,0))
-        end
-
+        BA2_UFilter(p)
         return ""
     elseif msg == "!dfilter" then
-        if p:GetNWInt("BA2_GasmaskFilters",0) == 0 then
-            p:ChatPrint("You don't have any reserve filters.")
-        else
-            BA2_DropFilter(p)
-            p:EmitSound("physics/metal/weapon_footstep2.wav")
-        end
-
+        BA2_DropFilter(p)
         return ""
     end
 end)

--- a/lua/ba2/methods.lua
+++ b/lua/ba2/methods.lua
@@ -1,6 +1,31 @@
 -- This file is separated from the main init function to allow modders to use BA2's most useful functions without reloading the server code again
 
-if SERVER then
+
+-- SHARED ------------------------------------------------------------------
+function BA2_GetValidAppearances()
+    local zomTypes = {}
+    if GetConVar("ba2_hs_appearance_0"):GetBool() then
+        table.insert(zomTypes,BA2_ZombieTypes[0])
+    end
+    if GetConVar("ba2_hs_appearance_1"):GetBool() then
+        table.insert(zomTypes,BA2_ZombieTypes[1])
+    end
+    if GetConVar("ba2_hs_appearance_2"):GetBool() then
+        table.insert(zomTypes,BA2_ZombieTypes[2])
+    end
+    if GetConVar("ba2_hs_appearance_3"):GetBool() then
+        table.insert(zomTypes,BA2_ZombieTypes[3])
+    end -- there's probably a shorter way to do this
+
+    if #zomTypes == 0 then
+        zomTypes = table.Copy(BA2_ZombieTypes)
+    end
+
+    return zomTypes
+end
+
+
+if SERVER then -- SERVER ---------------------------------------------------
 
 function BA2_AddInfection(ent,amnt)
     if amnt < 0 then return end
@@ -54,7 +79,7 @@ function BA2_RaiseZombie(ent)
     end
 
     for i = 1,ent:GetNumBodyGroups() do
-        table.insert(zom.InfBodyGroups, ent:GetBodygroup(i))
+        table.insert(zom.InfBodyGroups,ent:GetBodygroup(i))
     end
 
     zom:Spawn()

--- a/lua/entities/ba2_gasmask.lua
+++ b/lua/entities/ba2_gasmask.lua
@@ -29,7 +29,7 @@ function ENT:Use(p)
         p:SetNWBool("BA2_GasmaskOwned",true)
         p:SetNWInt("BA2_GasmaskFilterPct",self.BA2_FilterPct)
 
-            if p:GetInfoNum("ba2_cl_maskhelp",1) == 1 then
+        if p:GetInfoNum("ba2_cl_maskhelp",1) == 1 then
             p:ChatPrint([[
 You found a gas mask! It's now stored on your person.
 Type "!gasmask" in chat to put it on or take it off.
@@ -42,6 +42,7 @@ Type "!cfilter" to check on your current filter and see how many you have.
 Type "!dfilter" to drop one of your filters.]])
             end
             p:ChatPrint("\nDisable \"Gas Mask Help Text\" under Client settings to turn off this chat spam.")
+            p:ChatPrint("^^^ OPEN CHAT FOR INSTRUCTIONS! ^^^")
         end
         
         self:EmitSound("npc/combine_soldier/zipline_hitground1.wav")

--- a/lua/entities/ba2_hordespawner.lua
+++ b/lua/entities/ba2_hordespawner.lua
@@ -30,18 +30,19 @@ function ENT:Initialize()
     end
 
     self.zoms = {}
-    if SERVER then self.navs = navmesh.GetAllNavAreas() end
+    if SERVER then
+        self.navs = navmesh.GetAllNavAreas() 
+        self:SpawnZoms(math.random(5,10))
+        timer.Create("BA2_HordeSpawner",GetConVar("ba2_hs_interval"):GetFloat(),0,function()
+            if IsValid(self) then
+                self:SpawnZoms(math.random(5,10))
+            end
+        end)
+    end
 
     if CLIENT then
         EmitSound("ba2/infected/horde.wav",self:GetPos(),-1)
     end
-
-    self:SpawnZoms(math.random(5,10))
-    timer.Create("BA2_HordeSpawner",GetConVar("ba2_hs_interval"):GetFloat(),0,function()
-        if IsValid(self) then
-            self:SpawnZoms(math.random(5,10))
-        end
-    end)
 end
 
 function ENT:OnRemove()
@@ -60,17 +61,21 @@ function ENT:OnRemove()
 end
 
 
+if SERVER then
+
 function ENT:SpawnZoms(amnt)
     timer.Adjust("BA2_HordeSpawner",GetConVar("ba2_hs_interval"):GetFloat(),nil,nil)
     local zomThreshold = GetConVar("ba2_hs_max"):GetInt()
-    local zomType = GetConVar("ba2_hs_appearance"):GetInt()
-    if zomType == 4 then
-        zomType = BA2_ZombieTypes[math.random(0,3)]
-    elseif zomType == 5 then
-        zomType = BA2_ZombieTypes[math.random(0,2)]
-    else
-        zomType = BA2_ZombieTypes[zomType]
-    end 
+    -- local zomType = GetConVar("ba2_hs_appearance"):GetInt()
+    -- if zomType == 4 then
+    --     zomType = BA2_ZombieTypes[math.random(0,3)]
+    -- elseif zomType == 5 then
+    --     zomType = BA2_ZombieTypes[math.random(0,2)]
+    -- else
+    --     zomType = BA2_ZombieTypes[zomType]
+    -- end
+
+    local zomTypes = BA2_GetValidAppearances()
 
     if SERVER then
         for i = 1,amnt do
@@ -83,7 +88,7 @@ function ENT:SpawnZoms(amnt)
                     
                     local spawnPos = navArea:GetCenter()
 
-                    local zom = ents.Create(zomType)
+                    local zom = ents.Create(zomTypes[math.random(1,#zomTypes)])
 
                     for i,ent in pairs(ents.FindInSphere(spawnPos,GetConVar("ba2_hs_saferadius"):GetInt())) do
                         if zom:IsValidEnemy(ent) then
@@ -118,4 +123,6 @@ function ENT:SpawnZoms(amnt)
             end)
         end
     end
+end
+
 end

--- a/lua/entities/ba2_pointspawner.lua
+++ b/lua/entities/ba2_pointspawner.lua
@@ -37,17 +37,10 @@ function ENT:OnRemove()
 end
 
 function SpawnZom(s) -- This is just a neutered Horde Spawner
-    local zomType = GetConVar("ba2_hs_appearance"):GetInt()
-    if zomType == 4 then
-        zomType = BA2_ZombieTypes[math.random(0,3)]
-    elseif zomType == 5 then
-        zomType = BA2_ZombieTypes[math.random(0,2)]
-    else
-        zomType = BA2_ZombieTypes[zomType]
-    end
+    local zomTypes = BA2_GetValidAppearances()
 
     if SERVER then
-        local zom = ents.Create(zomType)
+        local zom = ents.Create(zomTypes[math.random(1,#zomTypes)])
         zom:SetPos(s:GetPos())
         zom:SetAngles(s:GetAngles())
         zom.noRise = true


### PR DESCRIPTION
Additions:
- Spawner zombie types are now toggleable by checkboxes instead of a list
- Complete VJ Base support
- Zombies can now be killed with pulse rifle balls
- Added convars for prop damage and limbshot damage multipliers
- Added console command equivalents for gasmask chat commands
- Updated About page with extra links

Tweaks:
- Changed name of internal team used for killfeed workaround to avoid confusion
- Chat notifications are given when the user chooses to generate a navmesh with the prompt
- Moved filter reserve HUD text to reduce clipping on small monitors
- Renamed Cosmetic options section to Customs
- Renamed Horde Spawner options section to Spawners

Fixes:
- Fixed zombie deaths not being detected in Horde gamemode
- Fixed doors reappearing instantly when ba2_zom_doorrespawn is 0 (whoops)
- Added blank NPC methods to reduce cross-addon errors
- Fixed NPCs not dropping their weapons when killed by infection