### PR TITLE
Fixed compatibility with some NPC functions

### DIFF
--- a/lua/entities/nb_ba2_infected.lua
+++ b/lua/entities/nb_ba2_infected.lua
@@ -1479,6 +1479,22 @@ function ENT:OnContact(ent)
 	end
 end
 
+-- https://wiki.facepunch.com/gmod/NPC:ClearSchedule
+function ENT:ClearSchedule() end
+
+-- https://wiki.facepunch.com/gmod/Enums/SCHED
+-- SCHED_COMBAT_FACE = 12
+function ENT:GetCurrentSchedule() return 12 end
+
+-- https://wiki.facepunch.com/gmod/NPC:IsCurrentSchedule
+function ENT:IsCurrentSchedule() return true end
+
+-- https://wiki.facepunch.com/gmod/NPC:SetSchedule
+function ENT:SetSchedule() end
+
+-- https://wiki.facepunch.com/gmod/NPC:SetTarget
+function ENT:SetTarget() end
+
 -- Error handling
 function ENT:GetActiveWeapon()
 	return NULL


### PR DESCRIPTION
Hi. I am the author of the "Background NPCs" addon. I have been sent a bug report several times already related to this mod:
![chrome_un3WoiXyW6](https://user-images.githubusercontent.com/13109606/142490299-9c0c6dad-49bd-4f3f-a6e2-f616459ed1a7.png)

Please add override of these functions. I use the scheduling functions, so their absence creates problems, given that NextBot is marked as an NPC.